### PR TITLE
Add cache clear on error for inc, touch, delete_many, add

### DIFF
--- a/django_elasticache/memcached.py
+++ b/django_elasticache/memcached.py
@@ -104,6 +104,10 @@ class ElastiCache(PyLibMCCache):
         return client
 
     @invalidate_cache_after_error
+    def add(self, *args, **kwargs):
+        return super(ElastiCache, self).add(*args, **kwargs)
+
+    @invalidate_cache_after_error
     def get(self, *args, **kwargs):
         return super(ElastiCache, self).get(*args, **kwargs)
 
@@ -120,5 +124,17 @@ class ElastiCache(PyLibMCCache):
         return super(ElastiCache, self).set_many(*args, **kwargs)
 
     @invalidate_cache_after_error
+    def incr(self, *args, **kwargs):
+        return super(ElastiCache, self).incr(*args, **kwargs)
+
+    @invalidate_cache_after_error
+    def touch(self, *args, **kwargs):
+        return super(ElastiCache, self).touch(*args, **kwargs)
+
+    @invalidate_cache_after_error
     def delete(self, *args, **kwargs):
         return super(ElastiCache, self).delete(*args, **kwargs)
+
+    @invalidate_cache_after_error
+    def delete_many(self, *args, **kwargs):
+        return super(ElastiCache, self).delete_many(*args, **kwargs)


### PR DESCRIPTION
This adds django-elasticache's exception handling to additional cache commands.
We were seeing some commands executed in a recent incident with logs suggesting the response was for a different type of command entirely. This could have been caused by any of these commands hitting exception cases like timeouts, then the response buffer being reused despite being half-full of data from the failed request.

I'm speculating a little, and we won't necessarily be able to see the issue without the accompanying timeouts / exceptions to verify, but it seems like a safe change to make. This certainly isn't the only thread safety issue in our cache library stack though.

Note: The original author even acknowledged the problem here, but the PR stalled due to unrelated changes
https://github.com/gusdan/django-elasticache/pull/27#issuecomment-424114955